### PR TITLE
Handle environment variables in development using .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PDFTK=`which pdftk`

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 2.0'
   gem 'quiet_assets'
   gem 'byebug'
+  gem 'dotenv-rails'  # set environment variables via the filesystem
 end
 
 gem 'pdf-forms', '0.5.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
     columnize (0.3.6)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
+    dotenv (0.9.0)
+    dotenv-rails (0.9.0)
+      dotenv (= 0.9.0)
     erubis (2.7.0)
     execjs (2.0.2)
     govuk_template (0.3.8)
@@ -146,6 +149,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  dotenv-rails
   govuk_frontend_toolkit!
   govuk_template (= 0.3.8)
   haml-rails


### PR DESCRIPTION
I was getting errors when running tests for some reason related to an incorrect path to pdftk.

The .env approach is preferred as it makes it clear which variables need to be set in production.
