### PR TITLE
Address fixing

### DIFF
--- a/app/assets/javascripts/address_copying.js
+++ b/app/assets/javascripts/address_copying.js
@@ -1,0 +1,89 @@
+/*jslint browser: true, evil: false, plusplus: true, white: true, indent: 2 */
+/*global moj, $ */
+
+moj.Modules.addressCopying = (function() {
+  "use strict";
+
+  var //functions
+      init,
+      cacheEls,
+      bindEvents,
+      copyAddresses,
+      copyAddress,
+      createFakeSubmitButton,
+      submitForm,
+
+      //elements
+      $addressPanels,
+      $form,
+      $submitButton,
+      $sourceAddressPanel,
+      $claimantOneAddressPanel,
+      $propertyAddressPanel
+      ;
+
+  init = function() {
+    cacheEls();
+    bindEvents();
+
+    createFakeSubmitButton();
+  };
+
+  cacheEls = function() {
+    $addressPanels = $( '#claimant_two, .sub-panel.defendant' );
+    $form = $( 'form#claimForm' ).eq( 0 );
+    $submitButton = $form.find( '#submit' );
+    $claimantOneAddressPanel = $( '.sub-panel#claimant_one' );
+    $propertyAddressPanel = $( '.sub-panel#property' );
+  };
+
+  bindEvents = function() {
+    $( document ).on( 'click', '#fakeSubmit', function( e ) {
+      e.preventDefault();
+
+      copyAddresses( function() {
+        submitForm();
+      } );
+    } ); 
+  };
+
+  createFakeSubmitButton = function() {
+    $submitButton.after( $submitButton.clone().attr( 'id', 'fakeSubmit' ) ).hide();
+  };
+
+  copyAddresses = function( callback ) {
+    $addressPanels.each( function() {
+      var $this = $( this ),
+          $sourceAddressPanel;
+
+      if( $this.find( 'input.yesno[value="yes"]' ).is( ':checked' ) ) {
+        if( $this.hasClass( 'claimant' ) ) {
+          $sourceAddressPanel = $claimantOneAddressPanel;
+        } else if( $this.hasClass( 'defendant' ) ) {
+          $sourceAddressPanel = $propertyAddressPanel;
+        }
+
+        copyAddress( $sourceAddressPanel, $this );
+      }
+    } );
+
+    callback();
+  };
+
+  copyAddress = function( $src, $target ) {
+    $target.find( '.street textarea' ).val( $src.find( '.street textarea' ).val() );
+    $target.find( '.town input[type="text"]' ).val( $src.find( '.town input[type="text"]' ).val() );
+    $target.find( '.postcode input[type="text"]' ).val( $src.find( '.postcode input[type="text"]' ).val() );
+  };
+
+  submitForm = function() {
+    $submitButton.click();
+  };
+
+  // public
+
+  return {
+    init: init
+  };
+
+}());

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -19,6 +19,7 @@
 //= require external_links
 //= require claimant_address
 //= require defendant_address
+//= require address_copying
 //= require show_hide
 //= require yes_no
 //= require main

--- a/app/views/claim/_property.html.haml
+++ b/app/views/claim/_property.html.haml
@@ -1,7 +1,8 @@
 = claim_form.fields_for property, builder: LabellingFormBuilder do |form|
-  = form.text_area_row  :street, class: 'street'
-  = form.text_field_row :town, class: 'rel town'
-  = form.text_field_row :postcode, class: 'rel postcode'
+  .sub-panel.address#property
+    = form.text_area_row  :street, class: 'street'
+    = form.text_field_row :town, class: 'rel town'
+    = form.text_field_row :postcode, class: 'rel postcode'
 
   = form.radio_button_fieldset :house, 'Type of property', class: 'striped-choice', choice: {'House' => 'Yes', 'Part of a house' => 'No'}
 

--- a/app/views/claim/new.html.haml
+++ b/app/views/claim/new.html.haml
@@ -2,7 +2,7 @@
 = render partial: 'shared/flash'
 = render partial: 'shared/error_messages'
 
-= form_for :claim, url: submission_path, :html => { :method => :post } do |claim_form|
+= form_for :claim, url: submission_path, :html => { :method => :post, :id => 'claimForm' } do |claim_form|
   %section
     %span.right
       %span.req> *
@@ -14,11 +14,11 @@
   %section
     %h3.section-header Claimant (landlord)
     .moj-panel
-      .sub-panel.claimant
+      .sub-panel.claimant#claimant_one
         %h4 Claimant 1
         = render partial: 'claimant', object: @claim.claimant_one, locals: { claim_form: claim_form, claimant_field: :claimant_one}
       .row.divider
-      .sub-panel.claimant.same-address
+      .sub-panel.claimant.same-address#claimant_two
         %h4.section-header Claimant 2
         = render partial: 'claimant', object: @claim.claimant_two, locals: { claim_form: claim_form, claimant_field: :claimant_two}
       .row.divider
@@ -74,7 +74,7 @@
 
   %section
     .action-buttons.cf
-      %button.button.primary.large.chevron.left{name: 'Complete form', value: ''} Complete form
+      %button.button.primary.large.chevron.left#submit{name: 'Complete form', value: ''} Complete form
 
 
 / handlebars templates

--- a/spec/javascript/address_copying.js
+++ b/spec/javascript/address_copying.js
@@ -1,0 +1,38 @@
+var url = casper.cli.get('url');
+
+casper.start(url + '/new', function() {
+
+  this.test.comment('Testing address copying');
+
+  this.fill('form#claimForm', {
+    'claim[property][street]':        '123 Property Street',
+    'claim[property][town]':          'London',
+    'claim[property][postcode]':      'W12 8QT',
+    
+    'claim[claimant_one][street]':    '22 Acacia Avenue',
+    'claim[claimant_one][town]':      'Birmingham',
+    'claim[claimant_one][postcode]':  'B15 2TT'
+  });
+
+  this.click( '#claimant2address-yes' );
+  this.click( '#defendant1address-yes' );
+  this.click( '#defendant2address-yes' );
+
+  this.click( '#fakeSubmit' );
+
+  this.test.assertField('claim[defendant_one][street]', '123 Property Street');
+  this.test.assertField('claim[defendant_one][town]', 'London');
+  this.test.assertField('claim[defendant_one][postcode]', 'W12 8QT');
+
+  this.test.assertField('claim[defendant_two][street]', '123 Property Street');
+  this.test.assertField('claim[defendant_two][town]', 'London');
+  this.test.assertField('claim[defendant_two][postcode]', 'W12 8QT');
+
+  this.test.assertField('claim[claimant_two][street]', '22 Acacia Avenue');
+  this.test.assertField('claim[claimant_two][town]', 'Birmingham');
+  this.test.assertField('claim[claimant_two][postcode]', 'B15 2TT');
+});
+
+casper.run(function() {
+  this.test.done();
+});


### PR DESCRIPTION
This fixes the empty fields in the PDF by copying property address to defendants and claimant 1 address to claimant 2 on form submit if the relevant radios are checked.
