### PR TITLE
Change git urls to use HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,9 @@ gem 'unicorn'
 
 # Gov.uk styles
 gem 'govuk_template', '0.3.8'
-gem 'govuk_frontend_toolkit', github: 'ministryofjustice/govuk_frontend_toolkit_gem', branch: 'asset-submodule'
+gem 'govuk_frontend_toolkit', git: 'https://github.com/ministryofjustice/govuk_frontend_toolkit_gem.git', branch: 'asset-submodule'
 # MOJ styles
-gem 'moj_boilerplate', github: 'ministryofjustice/moj_boilerplate', tag: 'v0.6.2'
+gem 'moj_boilerplate', git: 'https://github.com/ministryofjustice/moj_boilerplate.git', tag: 'v0.6.2'
 
 # required for feedback form
 gem 'zendesk_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/ministryofjustice/govuk_frontend_toolkit_gem.git
+  remote: https://github.com/ministryofjustice/govuk_frontend_toolkit_gem.git
   revision: 145acb0dbfd64ea08a5d62189deb7fb2365bd41f
   branch: asset-submodule
   specs:
@@ -8,7 +8,7 @@ GIT
       sass (>= 3.2.0)
 
 GIT
-  remote: git://github.com/ministryofjustice/moj_boilerplate.git
+  remote: https://github.com/ministryofjustice/moj_boilerplate.git
   revision: ce40310108938d5690a7844d7c9e8a92e0a81bd0
   tag: v0.6.2
   specs:


### PR DESCRIPTION
This is because Skyscape are currently blocking the git:// protocol.

They are working on unblocking it, but for the time being this will allow us to
deploy there.
