### PR TITLE
Switch MOJ boilerplate out for MOJ template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,10 +22,9 @@ gem 'jquery-rails'
 gem 'unicorn'
 
 # Gov.uk styles
-gem 'govuk_template', '0.3.8'
-gem 'govuk_frontend_toolkit', git: 'https://github.com/ministryofjustice/govuk_frontend_toolkit_gem.git', branch: 'asset-submodule'
+gem 'govuk_frontend_toolkit', '0.43.2'
 # MOJ styles
-gem 'moj_boilerplate', git: 'https://github.com/ministryofjustice/moj_boilerplate.git', tag: 'v0.6.2'
+gem 'moj_template', '0.10.0'
 
 # required for feedback form
 gem 'zendesk_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/govuk_frontend_toolkit_gem.git
-  revision: 145acb0dbfd64ea08a5d62189deb7fb2365bd41f
-  branch: asset-submodule
-  specs:
-    govuk_frontend_toolkit (0.39.0)
-      rails (>= 3.1.0)
-      sass (>= 3.2.0)
-
-GIT
-  remote: https://github.com/ministryofjustice/moj_boilerplate.git
-  revision: ce40310108938d5690a7844d7c9e8a92e0a81bd0
-  tag: v0.6.2
-  specs:
-    moj_boilerplate (0.6.2)
-      govuk_frontend_toolkit (= 0.39.0)
-      govuk_template (= 0.3.8)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,8 +72,9 @@ GEM
     fastercsv (1.5.5)
     ffi (1.9.3)
     formatador (0.2.4)
-    govuk_template (0.3.8)
-      rails (>= 3.1)
+    govuk_frontend_toolkit (0.43.2)
+      rails (>= 3.1.0)
+      sass (>= 3.2.0)
     guard (2.4.0)
       formatador (>= 0.2.4)
       listen (~> 2.1)
@@ -133,6 +116,8 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.5.2)
     minitest (4.7.5)
+    moj_template (0.10.0)
+      rails (>= 3.1)
     multi_json (1.8.4)
     multipart-post (2.0.0)
     nio4r (1.0.0)
@@ -269,14 +254,13 @@ DEPENDENCIES
   capybara
   ci_reporter
   dotenv-rails
-  govuk_frontend_toolkit!
-  govuk_template (= 0.3.8)
+  govuk_frontend_toolkit (= 0.43.2)
   guard-rspec
   haml-rails
   jquery-rails
   launchy
   mail
-  moj_boilerplate!
+  moj_template (= 0.10.0)
   pdf-forms (= 0.5.5)
   quiet_assets
   rails (= 4.0.3)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,4 +1,16 @@
 - content_for :page_title do
   = "#{@page_title} - "
 
+- content_for :stylesheets do
+  = stylesheet_link_tag "application", media: "all"
+
+- content_for :javascripts do
+  = javascript_include_tag "application"
+
+- content_for :head do
+  = csrf_meta_tag
+
+- content_for :cookie_message do
+  %p GOV.UK uses cookies to make the site simpler. #{link_to 'Find out more about cookies', 'https://www.gov.uk/help/cookies'}
+
 = render template: "layouts/moj_template"


### PR DESCRIPTION
Once this is merged, Max's cookie page (separate branch) can be linked to
