### PR TITLE
Fix for Brakeman warnings

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,6 +7,7 @@ function msg {
     echo -e "\n\n\n -----------> ${1} <-----------"
 }
 
+
 msg "installing gems"
 bundle install --deployment --without development --path vendor/bundler
 
@@ -14,4 +15,5 @@ msg "setting up CI & running the specs"
 RAILS_ENV=test bundle exec rake ci:setup:rspec spec
 
 msg "running brakeman"
+export LANG=en_GB.UTF-8 # leave this for brakeman
 bundle exec brakeman -z


### PR DESCRIPTION
Brakeman complains with:

+Errors+
+-----------------------------------+----------------------------------------->>
| Error                             | Location                                >>
+-----------------------------------+----------------------------------------->>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xC2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
| Invalid US-ASCII character "\xE2" | While compiling HAML in /Users/civilclai>>
+-----------------------------------+----------------------------------------->>

This commit is there to set the language environment.
