### PR TITLE
Fix logic showing checkboxes contingent on tenancy start date

### DIFF
--- a/app/assets/javascripts/tenancy_module.js
+++ b/app/assets/javascripts/tenancy_module.js
@@ -29,6 +29,8 @@ moj.Modules.tenancyModule = (function() {
     bindEvents();
 
     $optionsDiv.addClass( 'inset' ).find( '.inset' ).removeClass( 'inset' ).removeClass( 'sub-panel' );
+
+    $('#read-statements').text('Read the statements below and select all that apply:');
   };
 
   cacheEls = function() {
@@ -62,7 +64,7 @@ moj.Modules.tenancyModule = (function() {
     }
 
     checkDates();
-    
+
     if( $('.date-picker.selected').length === 0 ) {
       hideConditionals();
     }
@@ -82,16 +84,16 @@ moj.Modules.tenancyModule = (function() {
 
     for( x = 0; x < visDates.length; x++) {
       d = $( visDates[ x ] ).find( '.day' ).val();
-      m = ( $( visDates[ x ] ).find( '.month' ).val() - 1 );
+      m = ( $( visDates[ x ] ).find( '.month' ).val() );
       y = $( visDates[ x ] ).find( '.year' ).val();
 
       if( d !== '' && m !== '' && y !== '') {
         selectedDate = moj.Modules.tools.stringToDate( y + '-' + m + '-' + d );
       }
 
-      if( selectedDate > firstDate && selectedDate <= secondDate ) {
+      if( selectedDate >= firstDate && selectedDate < secondDate ) {
         showOlder = true;
-      } else if( selectedDate > secondDate ) {
+      } else if( selectedDate >= secondDate ) {
         showCurrent = true;
       }
     }

--- a/app/views/claim/_tenancy.html.haml
+++ b/app/views/claim/_tenancy.html.haml
@@ -43,12 +43,12 @@
             %li{ id: form.id_for(:applicable_statements_3, 'as3').to_s }
               = form.labelled_check_box :applicable_statements_3, 'The defendant is not living in the property as an agricultural worker in connection with their work (so Schedule 3, Housing Act 1988 does not apply) '.html_safe
 
-        %p.remove
+        %p.statements.remove
           %strong (or)
 
-          -# TODO: 'Read the statements below and select all that apply:' in JS version instead of the paragraph below.
-
-          %p= "If your tenancy agreement was made between <strong>#{Tenancy::APPLICABLE_FROM_DATE.to_s(:printed)} and #{(Tenancy::RULES_CHANGE_DATE - 1).to_s(:printed)}</strong>, read the statements below and select all that apply:".html_safe
+        .statements.hide.older
+          -# following paragraph replaced when JS turned on - see tenancy_module.js
+          %p#read-statements= "If your tenancy agreement was made between <strong>#{Tenancy::APPLICABLE_FROM_DATE.to_s(:printed)} and #{(Tenancy::RULES_CHANGE_DATE - 1).to_s(:printed)}</strong>, read the statements below and select all that apply:".html_safe
 
           %p
             %strong Select all that apply:


### PR DESCRIPTION
- Fixes JS so:
  - First checkboxes show when start date is on or after 15 January 1987.
  - Second checkboxes show when start date is on or after 28 February 1997.
- Change checkbox instruction text when JS enabled
