### PR TITLE
Validation for Notice attributes

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,10 +1,10 @@
 class Notice < BaseClass
 
   attr_accessor :served_by_name
-  validates :served_by_name, presence: { message: 'must be entered' }, length: { maximum: 70 }
+  validates :served_by_name, presence: { message: 'must be entered' }, length: { maximum: 40 }
 
   attr_accessor :served_method
-  validates :served_method, presence: { message: 'must be entered' }, length: { maximum: 35 }
+  validates :served_method, presence: { message: 'must be entered' }, length: { maximum: 40 }
 
   attr_accessor :date_served
   validates :date_served, presence: { message: 'must be entered' }

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -36,8 +36,8 @@ describe Notice do
       notice.should_not be_valid
     end
 
-    it "should be under 70 characters" do
-      notice.served_by_name = "x" * 71
+    it "should be up to 40 characters" do
+      notice.served_by_name = "x" * 41
       notice.should_not be_valid
     end
   end
@@ -48,8 +48,8 @@ describe Notice do
       notice.should_not be_valid
     end
 
-    it "should be under 35 characters" do
-      notice.served_method = "x" * 36
+    it "should be up to 40 characters" do
+      notice.served_method = "x" * 41
       notice.should_not be_valid
     end
   end


### PR DESCRIPTION
Moved served_by_name & served_method validations to both be up to 40
characters as per ticket:
https://www.pivotaltracker.com/story/show/72073540
