### PR TITLE
Override the pillar data for Vagrant so that we don't ask for a password.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cp /srv/salt/minions/vagrant/templates/minion /etc/salt/minion
     service salt-minion restart
     sleep 5 # This might not be needed, but why rush these things?
-    salt-call state.highstate --local --retcode-passthrough
+    salt-call state.highstate --local --retcode-passthrough pillar="{htaccess_users: ~}"
   SCRIPT
   config.vm.provision :shell, inline: script, keep_color: false
 


### PR DESCRIPTION
This is needed because there is now a default/placeholder htpasswd of
'****' in base env to make the pillar tests pass.
