### PR TITLE
Enabling server startup in all environments except production without Cr...

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,5 @@ Please remember to set the environment **SECRET_KEY_BASE** variable.
 Load testing is done through the tsung-wrapper repo.
 
 Tsung cannot cope with sending back Rails CSRF authenticity tokens, so the server has to be run without CSRF protection for loadtesting.  This is 
-acheived by setting an environment variable CC_NO_CSRF to '1'.  Setting this environment variable in production environment has no effect.
-
+acheived by setting an environment variable CC_NO_CSRF to any value.
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null session instead.
-  if Rails.env.production? || ENV['CC_NO_CSRF'] != '1'
+  if ENV['CC_NO_CSRF'].nil?
     protect_from_forgery with: :exception
   end
 


### PR DESCRIPTION
Enable server to be started in all environments except production without Cross Site
Request Forgery protection if CC-NO_CSRF environment variable is set (used for load testing).
