### PR TITLE
Fix JS event handler removal

### DIFF
--- a/app/assets/javascripts/event_tracker.coffee
+++ b/app/assets/javascripts/event_tracker.coffee
@@ -5,14 +5,20 @@ root.dispatchTrackingEvent = (category, action, label) ->
 
 class EventTracker
   constructor: ($) ->
-    $('[data-event-label]').on 'click', @onClick
+    @bind $('[data-event-label]'), 'click', @onClick
+
+  bind: (elements, event, handler) ->
+    _.each( elements, (element) =>
+      selector = '#' + element.id
+      $('body').on event, selector, handler )
 
   onClick: (event) ->
     category = this['href'].replace(/https?:\/\/[^\/]+/i, '')
     action = this.text
     label = $(this).data('event-label')
     root.dispatchTrackingEvent(category, action, label)
-    $(this).off 'click', @onClick
+    selector = '#' + this.id
+    $('body').off 'click', selector, @onClick
     return true
 
 root.EventTracker = EventTracker

--- a/app/assets/javascripts/pageview_tracker.coffee
+++ b/app/assets/javascripts/pageview_tracker.coffee
@@ -11,22 +11,29 @@ class PageviewTracker
     inputs = $('input[data-virtual-pageview]')
     links = $('a[data-virtual-pageview]')
 
-    textInput.on 'focusout', @onFocusOut
-    inputs.on 'click', @onClick
-    links.on 'click', @onClick
+    @bind textInput, 'focusout', @onFocusOut
+    @bind inputs, 'click', @onClick
+    @bind links, 'click', @onClick
+
+  bind: (elements, event, handler) ->
+    _.each( elements, (element) =>
+      selector = '#' + element.id
+      $('body').on event, selector, handler )
 
   onFocusOut: (event) ->
     if @value.length > 0
       url = $(this).data('virtual-pageview')
       root.dispatchPageView url
-      $(this).off 'focusout', @onFocusOut
+      selector = '#' + this.id
+      $('body').off 'focusout', selector, @onFocusOut
     return true
 
   onClick: (event) ->
     if @type != 'text'
       url = $(this).data('virtual-pageview')
       root.dispatchPageView url
-      $(this).off 'click', @onClick
+      selector = '#' + this.id
+      $('body').off 'click', selector, @onClick
     return true
 
 root.PageviewTracker = PageviewTracker

--- a/app/views/claim/confirmation.html.haml
+++ b/app/views/claim/confirmation.html.haml
@@ -5,6 +5,7 @@
         download_path,
         class: 'button large chevron pdf-download',
         target: '_blank',
+        id: 'download',
         data: { 'event-label' => 'View and print completed form',
         'virtual-pageview' => '/accelerated-possession-eviction/download' }
     %p
@@ -14,6 +15,7 @@
           class: 'external',
           rel: 'external',
           target: '_blank',
+          id: 'done',
           data: { 'event-label' => 'View GDS done page',
           'virtual-pageview' => '/done/accelerated-possession-eviction' }) + '.'
       %br/

--- a/spec/features/show_hide_spec.rb
+++ b/spec/features/show_hide_spec.rb
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+feature 'Show and hide tenancy section' do
+
+  before do
+    WebMock.disable_net_connect!(:allow => "127.0.0.1")
+  end
+
+  scenario 'select assured', js: true do
+    visit '/'
+    choose('claim_tenancy_tenancy_type_assured')
+    expect(page).to have_content("How many tenancy agreements have you had with the defendant?")
+  end
+
+  scenario 'select assured, then demoted', js: true do
+    visit '/'
+    choose('claim_tenancy_tenancy_type_assured')
+    choose('claim_tenancy_tenancy_type_demoted')
+    expect(page).to_not have_content("How many tenancy agreements have you had with the defendant?")
+    expect(page).to have_content("Date of demotion order")
+  end
+
+  scenario 'select assured, then demoted, then assured', js: true do
+    visit '/'
+    choose('claim_tenancy_tenancy_type_assured')
+    choose('claim_tenancy_tenancy_type_demoted')
+    choose('claim_tenancy_tenancy_type_assured')
+    expect(page).to have_content("How many tenancy agreements have you had with the defendant?")
+    expect(page).to_not have_content("Date of demotion order")
+  end
+
+end

--- a/spec/javascripts/event_tracker_spec.coffee
+++ b/spec/javascripts/event_tracker_spec.coffee
@@ -3,18 +3,31 @@
 //= require event_tracker
 
 describe 'EventTracker', ->
+  element = null
+
+  beforeEach ->
+    element = $('<form id="claimForm">' +
+      '<a id="a_link" data-event-label="data event label" data-virtual-pageview="/clicked_pageview" href="/clicked_event">Link event text</a>' +
+      '</form>')
+    $(document.body).append(element)
+
+  afterEach ->
+    element.remove()
+    element = null
 
   describe 'click on "data-event-label" element', ->
     it "dispatches analytics event", ->
-      element = $('<form id="claimForm">' +
-        '<a id="a_link" data-event-label="data event label" data-virtual-pageview="/clicked_pageview" href="/clicked_event">Link event text</a>' +
-        '</form>')
-      $(document.body).append(element)
-
       track = new window.EventTracker($)
       spyOn window, 'dispatchTrackingEvent'
       $('[data-event-label]').trigger 'click'
 
       expect(window.dispatchTrackingEvent).toHaveBeenCalledWith(jasmine.any(String), 'Link event text', 'data event label')
-      element.remove()
+
+  describe 'second click on "data-event-label" element', ->
+    it "dispatches analytics event", ->
+      track = new window.EventTracker($)
+      $('[data-event-label]').trigger 'click'
+      spyOn window, 'dispatchTrackingEvent'
+
+      expect(window.dispatchTrackingEvent).not.toHaveBeenCalled()
 

--- a/spec/javascripts/pageview_tracker_spec.coffee
+++ b/spec/javascripts/pageview_tracker_spec.coffee
@@ -1,3 +1,4 @@
+//= require underscore
 //= require jquery
 //= require jasmine-jquery
 //= require pageview_tracker
@@ -7,11 +8,11 @@ describe 'PageviewTracker', ->
   track = null
 
   beforeEach ->
-    element = $('<form id="claimForm">' +
+    element = $('<body><form id="claimForm">' +
       '<a id="a_link" data-event-label="data event label" data-virtual-pageview="/clicked_pageview" href="/clicked_event">Link event text</a>' +
       '<input data-virtual-pageview="/text" id="text_input" type="text" />' +
       '<input data-virtual-pageview="/radio" id="radio_input" type="radio" value="Yes" />' +
-      '</form>')
+      '</form></body>')
     $(document.body).append(element)
     track = new window.PageviewTracker($)
 
@@ -27,6 +28,14 @@ describe 'PageviewTracker', ->
 
         expect(window.dispatchPageView).toHaveBeenCalledWith('/clicked_pageview')
 
+    describe 'on second click', ->
+      it 'does not dispatch pageview', ->
+        $('#a_link').trigger 'click'
+        spyOn window, 'dispatchPageView'
+        $('#a_link').trigger 'click'
+
+        expect(window.dispatchPageView).not.toHaveBeenCalled()
+
   describe '"data-virtual-pageview" non-text input', ->
     describe 'on first click', ->
       it 'dispatches pageview', ->
@@ -38,7 +47,6 @@ describe 'PageviewTracker', ->
     describe 'on second click', ->
       it 'does not dispatch pageview', ->
         $('#radio_input').trigger 'click'
-
         spyOn window, 'dispatchPageView'
         $('#radio_input').trigger 'click'
 
@@ -53,6 +61,15 @@ describe 'PageviewTracker', ->
         textInput.focusout()
 
         expect(window.dispatchPageView).toHaveBeenCalled()
+
+    describe 'on second focus out', ->
+      it 'does not dispatch virtual pageview', ->
+        textInput = $('#text_input')
+        textInput.val('something entered')
+        textInput.focusout()
+        spyOn window, 'dispatchPageView'
+        textInput.focusout()
+        expect(window.dispatchPageView).not.toHaveBeenCalled()
 
     describe 'when input does not contain text', ->
       it 'does not dispatch virtual pageview', ->


### PR DESCRIPTION
- Corrected usage of the jQuery .off( events [, selector ] [, handler ] ) function
- Use element's id as a selector to remove it via off() function
