### PR TITLE
Error message for Deposit type

### DIFF
--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -13,7 +13,7 @@ class Deposit < BaseClass
 
   attr_accessor :as_money
   validates :as_money, presence: { message: 'must be selected' }, inclusion: { in: ['Yes', 'No'] }
-  
+
   validate :money_or_property_must_be_selected_if_received
 
 
@@ -36,7 +36,7 @@ class Deposit < BaseClass
   def money_or_property_must_be_selected_if_received
     if received && received == 'Yes'
       if as_money == 'No' && as_property == 'No'
-        errors[:as_money] = "or As Property must be selected as the type of deposit"
+        errors[:deposit_type] = 'must be selected'
       end
     end
   end

--- a/app/views/claim/_deposit.html.haml
+++ b/app/views/claim/_deposit.html.haml
@@ -5,10 +5,12 @@
       class: 'radio inline js-depend',
       data: { depend: 'deposit', 'virtual-pageview' => '/accelerated/deposit-section' }
 
-  %fieldset.hide.js-deposit.yes.radio.js-depend{ id: 'deposit_type_fieldset' }
-    %h3
+  %fieldset.hide.js-deposit.yes.radio.js-depend{ class: (form.error_for?(:deposit_type) ? 'error' : ''), id: (form.error_for?(:deposit_type) ? form.error_id_for(:deposit_type) : 'deposit_type_fieldset') }
+    %legend
       %span.nonjs(data-jsalt='What') If <strong>yes</strong>, what
       kind of deposit?
+      - if form.error_for?(:deposit_type)
+        %span.error must be answered
     .options
       - form.row :as_money do
         = form.labelled_check_box :as_money, 'A money deposit <span class="hint block">For example cash or cheque</span>'.html_safe, 'Yes', 'No', data: {depend: 'depositTypeMoney'}

--- a/spec/models/deposit_spec.rb
+++ b/spec/models/deposit_spec.rb
@@ -78,9 +78,9 @@ describe Deposit, :type => :model do
                             ref_number: 'x123',
                             as_property: 'No',
                             as_money: 'No',
-                            information_given_date: Date.parse("2010-01-10")) 
+                            information_given_date: Date.parse("2010-01-10"))
       expect(deposit).not_to be_valid
-      expect(deposit.errors[:as_money]).to eq(["or As Property must be selected as the type of deposit"])
+      expect(deposit.errors[:deposit_type]).to eq(['must be selected'])
     end
 
     it 'should validate if both money and property are selected' do


### PR DESCRIPTION
When the deposit is selected but no deposit type is specified, the
correct error message is displayed, that encloses both money deposit and
valuable item options.
