### PR TITLE
Validation for Deposit ref_number

### DIFF
--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -29,6 +29,10 @@ class Deposit < BaseClass
     deposit.validates :ref_number, presence: true
   end
 
+  with_options if: -> deposit { deposit.received == 'Yes' && deposit.as_money == 'No'} do |deposit|
+    deposit.validates :ref_number, absence: { message: 'must be provided only if money deposit taken' }
+  end
+
   def as_json
     json = super
     json = split_date :information_given_date, json

--- a/spec/models/deposit_spec.rb
+++ b/spec/models/deposit_spec.rb
@@ -64,6 +64,25 @@ describe Deposit, :type => :model do
       end
     end
 
+    describe 'when the deposit has been given' do
+      context 'but only as property' do
+        before do
+          deposit.as_property = 'Yes'
+          deposit.as_money = 'No'
+        end
+
+        it 'should not be valid' do
+          expect(deposit).not_to be_valid
+        end
+
+        it 'should have an error message' do
+          deposit.valid?
+          err = 'must be provided only if money deposit taken'
+          expect(deposit.errors[:ref_number]).to eq([err])
+        end
+      end
+    end
+
     describe 'as_json' do
       it 'should return correct json' do
         expect(deposit.as_json).to eq({


### PR DESCRIPTION
In cases when the deposit is given as payment then the reference number
must be provided.
