### PR TITLE
Redirect the user back from AD form once done

### DIFF
--- a/app/views/user_callback/new.html.haml
+++ b/app/views/user_callback/new.html.haml
@@ -7,6 +7,8 @@
   %p
     %strong Please note: we cannot offer legal advice.
 
+    = render partial: 'shared/flash'
+
     - unless @user_callback.errors.messages.blank?
       %section.flash.error-summary
         %h2#error-heading You need to fix the errors on this page before continuing.

--- a/spec/features/callback_spec.rb
+++ b/spec/features/callback_spec.rb
@@ -53,7 +53,21 @@ feature 'Callback request' do
 
       fill_in_the_form_correctly
 
+      expect(page).not_to have_content('Thank you we will call you back during the next working day between 9am and 5pm.')
+
       expect(current_path).to eq '/feedback/new'
+    end
+
+    scenario 'go back to technical help page' do
+      visit '/ask-for-technical-help'
+      click_link 'Technical help'
+      expect(page).to have_content('Ask for technical help')
+
+      fill_in_the_form_correctly
+
+      expect(page).to have_content('Thank you we will call you back during the next working day between 9am and 5pm.')
+
+      expect(current_path).to eq '/ask-for-technical-help'
     end
   end
 end


### PR DESCRIPTION
Redirect the user back to the URL (s)he came from once they fill in the
AD form.

After completing the request, take the user back to the page they
originated from and flash the message. But if the user came back from
the feedback form message, still return them back but don't flash the
message.
