### PR TITLE
Increase poltergeist timeout, prevents some intermittent failures

### DIFF
--- a/spec/poltergeist_setup.rb
+++ b/spec/poltergeist_setup.rb
@@ -2,6 +2,7 @@ require 'capybara/poltergeist'
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app,
+    :timeout => 60,
     :phantomjs_options => ['--ignore-ssl-errors=yes']
     # :phantomjs_logger => open('/dev/null')
   )


### PR DESCRIPTION
This seems to make things a bit more reliable under Ubuntu with phantomjs. 
