### PR TITLE
Updated Code Climate badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Build Status](http://jenkins.dsd.io/view/Civil%20Claims%20Dashboard/job/civilclaims-accelerated-test/badge/icon)](http://ec2-54-194-212-120.eu-west-1.compute.amazonaws.com/view/Civil%20Claims%20Dashboard/job/civilclaims-accelerated-test/)
 
-[![Code Climate](https://codeclimate.com/github/ministryofjustice/accelerated_claims.png)](https://codeclimate.com/github/ministryofjustice/accelerated_claims)
+[![Code Climate](https://codeclimate.com/github/ministryofjustice/accelerated_claims/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/accelerated_claims)
+
+[![Test Coverage](https://codeclimate.com/github/ministryofjustice/accelerated_claims/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/accelerated_claims)
 
 This is the source code of what is currently a minimum viable product for the Civil Claims exemplar. The application consists in a single form that claimants of accelerated claims fill out to download a PDF. The PDF is the standard accelerated claim form from HMCTS, is filled out with the details that the claimant has provided, and can be signed and sent by post.
 
@@ -156,4 +158,3 @@ Load testing is done through the tsung-wrapper repo.
 
 Tsung cannot cope with sending back Rails CSRF authenticity tokens, so the server has to be run without CSRF protection for loadtesting.  This is
 acheived by setting an environment variable CC_NO_CSRF to any value.
-


### PR DESCRIPTION
I've replaced the one linking to the repo as it was advised by the Code Climate docs.

I've added the test coverage badge also.
