### PR TITLE
Skip non-js capybara tests on remote

### DIFF
--- a/spec/features/form_validation_errors_spec.rb
+++ b/spec/features/form_validation_errors_spec.rb
@@ -295,7 +295,6 @@ feature 'Filling in claim form' do
             expect(page).to have_content( non_js_address_error_message("Claimant contact's") )
         end
 
-
         scenario 'defendant_1 address is invalid' do
             visit '/'
             fill_in('claim_defendant_1_street', with: invalid_address)


### PR DESCRIPTION
guard non-js capybara tests with unless_remote? to prevent test failures when running remotely.
