### PR TITLE
Accessibility 2

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -19,6 +19,7 @@
 //= require animate
 
 //= require address_module
+//= require error_focus_module
 //= require property_module
 //= require select_state
 //= require yes_no

--- a/app/assets/javascripts/error_focus_module.coffee
+++ b/app/assets/javascripts/error_focus_module.coffee
@@ -1,0 +1,16 @@
+root = exports ? this
+
+ErrorFocusModule = 
+
+  focusOnErrorSection: ->
+    if $('#form_errors').length > 0
+      $('#form_errors').focus()
+
+  setup: ->
+    ErrorFocusModule.focusOnErrorSection()
+
+
+root.ErrorFocusModule = ErrorFocusModule
+
+jQuery ->
+  ErrorFocusModule.setup()

--- a/app/views/claim/_fee.html.haml
+++ b/app/views/claim/_fee.html.haml
@@ -1,8 +1,8 @@
 = claim_form.fields_for fee, builder: LabellingFormBuilder do |form|
   .row
-    = 'Court fee <span class=\'hint block\'>Enclose a cheque with the completed claim form</span>'.html_safe
+    %label{for: "claim_fee_court_fee", class: "visuallyhidden"}= "Court fee - There is a fixed fee of two hundred and eighty pounds and no pence.  Enclose a check with the completed claim form.  This is not an editable text field." 
+    = 'Court fee <span class=\'hint block\', aria-hidden="true">Enclose a cheque with the completed claim form</span>'.html_safe
     = form.text_field :court_fee, class: 'fee pound', readonly: true
-
   - if false # hide link to PDF while fee is hardcoded
     .row
       %p See the latest #{link_to 'court fees', 'http://hmctsformfinder.justice.gov.uk/courtfinder/forms/ex050-eng.pdf', class: 'external', rel: 'external', target: '_blank'}

--- a/app/views/claim/_legal_cost.html.haml
+++ b/app/views/claim/_legal_cost.html.haml
@@ -1,3 +1,3 @@
 = claim_form.fields_for legal_cost, builder: LabellingFormBuilder do |form|
   .sub-panel
-    = form.text_field_row :legal_costs, label: 'Fixed legal fees <span class=\'hint block\'>If the form is being completed by a legal representative</span>'.html_safe, input_class: 'pound', maxlength: 8
+    = form.text_field_row :legal_costs, label: '<span class="visuallyhidden">Fixed legal fees. Enter in pounds</span> <span aria-hidden="true">Fixed legal fees</span> <span class=\'hint block\'>If the form is being completed by a legal representative</span>'.html_safe, input_class: 'pound', maxlength: 8

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,5 +1,5 @@
 - if @errors
-  %section#form_errors.flash.error-summary
+  %section#form_errors.flash.error-summary{tabindex: "-1"}
     %h2#error-heading You need to fix the errors on this page before continuing.
 
     %p See highlighted errors below.

--- a/app/views/user_callback/new.html.haml
+++ b/app/views/user_callback/new.html.haml
@@ -10,7 +10,7 @@
     = render partial: 'shared/flash'
 
     - unless @user_callback.errors.messages.blank?
-      %section.flash.error-summary
+      %section.flash.error-summary{tabindex: "-1"}
         %h2#error-heading You need to fix the errors on this page before continuing.
 
         %p See highlighted errors below.

--- a/spec/javascripts/claimant_module_spec.coffee
+++ b/spec/javascripts/claimant_module_spec.coffee
@@ -93,6 +93,7 @@ describe 'ClaimantModule', ->
         $('#claim_num_claimants').val('2')
         $('#claim_num_claimants').trigger 'keyup'
         expect(window.ClaimantModule.showClaimants).toHaveBeenCalledWith('2')
+        
 
   describe 'switching claimant type', ->
 

--- a/spec/javascripts/error_focus_module_spec.coffee
+++ b/spec/javascripts/error_focus_module_spec.coffee
@@ -1,0 +1,14 @@
+//= require underscore
+//= require jquery
+//= require jasmine-jquery
+//= require error_focus_module
+
+
+describe 'ErrorFocusModule', ->
+
+  describe 'setup', ->
+    it 'should call focusOnErrorSection()', ->
+      spyOn window.ErrorFocusModule, 'focusOnErrorSection'
+      ErrorFocusModule.setup()
+      expect(window.ErrorFocusModule.focusOnErrorSection).toHaveBeenCalled
+      expect(window.ErrorFocusModule.focusOnErrorSection.calls.count()).toBe 1


### PR DESCRIPTION
Fixes three issues raised by GDS:
- Focus should be switched to error panel on page load if there are any errors
- legend for currency text field does not read the £ symbol because it is not part of the label - this has been overcome by giving different legends for text readers vs sighted users
- legend for readonly text field does not make it clear that it is a readonly text field - same approach as above used.
