### PR TITLE
fixed duplicate error id

### DIFF
--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,6 +1,6 @@
 - if @errors
   %section#form_errors.flash.error-summary{tabindex: "-1"}
-    %h2#error-heading You need to fix the errors on this page before continuing.
+    %h2#page-error-heading You need to fix the errors on this page before continuing.
 
     %p See highlighted errors below.
 


### PR DESCRIPTION
The id error-heading is used further down the page too, for 'You cannot continue this claim'.
Once the page is committed with errors, the duplicate id means the page fails validation.
