### PR TITLE
Adding configuration for HoundCI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,6 @@
+ruby:
+  enabled: true
+  config_file: config/.rubocop.yml
+
+coffee_script:
+  enabled: true

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  RunRailsCops: true


### PR DESCRIPTION
In order to prevent any future conflicts (due to whitespace) when merging, this service will create comments pointing out any sloppy whitespace introduction.

It will allow [HoundCI](https://houndci.com/) to run [Rubocop](https://github.com/bbatsov/rubocop) and [Coffeelint](http://www.coffeelint.org/) on any new code introduced by the pull requests.
