### PR TITLE
ie8 address button issue

### DIFF
--- a/app/assets/stylesheets/postcode-picker.css.sass
+++ b/app/assets/stylesheets/postcode-picker.css.sass
@@ -26,7 +26,6 @@
 
   .postcode-picker-cta
     margin-top: 10px
-    width: 124px
 
   .postcode-picker-hourglass
     color: $grey-1


### PR DESCRIPTION
The width was added during the progressive defendant reveal, but does not seem to be necessary now.  Apart from breaking IE8!
