### PR TITLE
WIP - added prototype for visually hidden descriptive spans

### DIFF
--- a/app/helpers/labelling_form_builder.rb
+++ b/app/helpers/labelling_form_builder.rb
@@ -281,7 +281,11 @@ class LabellingFormBuilder < ActionView::Helpers::FormBuilder
     css = "form-group #{css_for(attribute, options)}".strip
     id = id_for(attribute).blank? ? '' : "id='#{id_for(attribute)}' "
 
-    sr_text = "<span class='visuallyhidden'>#{ options[:sr_text] }</span> "
+    if options[:sr_text].nil?
+      sr_text = nil
+    else
+      sr_text = "<span class='visuallyhidden'>#{ options[:sr_text] }</span> "
+    end
 
     @template.surround("<div #{id}class='#{css}'>".html_safe, "</div>".html_safe) do
       input_options = options.merge(class: options[:input_class])
@@ -290,12 +294,14 @@ class LabellingFormBuilder < ActionView::Helpers::FormBuilder
       input_options.delete(:input_class)
       input_options.delete(:sr_text)
 
-      labelled_input attribute, input, input_options, options[:label], sr_text
+      labelled_input attribute, input, input_options,
+                     options[:label], options[:sr_text]
     end
   end
 
-  def labelled_input(attribute, input, input_options, label = nil, screenreader = nil)
-    txt = "#{screenreader}#{label_content_for(attribute, label)}".html_safe
+  def labelled_input(attribute, input, input_options,
+                     label = nil, sr_text = nil)
+    txt = "#{sr_text}#{label_content_for(attribute, label)}".html_safe
     label = label(attribute, txt)
 
     if max_length = max_length(attribute)

--- a/app/helpers/labelling_form_builder.rb
+++ b/app/helpers/labelling_form_builder.rb
@@ -281,18 +281,24 @@ class LabellingFormBuilder < ActionView::Helpers::FormBuilder
     css = "form-group #{css_for(attribute, options)}".strip
     id = id_for(attribute).blank? ? '' : "id='#{id_for(attribute)}' "
 
+    screenreader = options[:include_object_for_sr].blank? ? '' : "<span class='visuallyhidden'>#{ options[:include_object_for_sr] }</span> "
+
     @template.surround("<div #{id}class='#{css}'>".html_safe, "</div>".html_safe) do
       input_options = options.merge(class: options[:input_class])
       input_options.merge!(data: {'virtual_pageview' => virtual_pageview}) if virtual_pageview
       input_options.delete(:label)
       input_options.delete(:input_class)
+      input_options.delete(:include_object_for_sr)
 
-      labelled_input attribute, input, input_options, options[:label]
+      labelled_input attribute, input, input_options, options[:label], screenreader
     end
   end
 
-  def labelled_input attribute, input, input_options, label=nil
-    label = label(attribute, label_content_for(attribute, label))
+  def labelled_input attribute, input, input_options, label=nil, screenreader=nil
+
+    txt = "#{screenreader}#{label_content_for(attribute, label)}".html_safe
+
+    label = label(attribute, txt )
 
     if max_length = max_length(attribute)
       input_options.merge!(maxlength: max_length)

--- a/app/helpers/labelling_form_builder.rb
+++ b/app/helpers/labelling_form_builder.rb
@@ -281,24 +281,22 @@ class LabellingFormBuilder < ActionView::Helpers::FormBuilder
     css = "form-group #{css_for(attribute, options)}".strip
     id = id_for(attribute).blank? ? '' : "id='#{id_for(attribute)}' "
 
-    screenreader = options[:include_object_for_sr].blank? ? '' : "<span class='visuallyhidden'>#{ options[:include_object_for_sr] }</span> "
+    sr_text = "<span class='visuallyhidden'>#{ options[:sr_text] }</span> "
 
     @template.surround("<div #{id}class='#{css}'>".html_safe, "</div>".html_safe) do
       input_options = options.merge(class: options[:input_class])
       input_options.merge!(data: {'virtual_pageview' => virtual_pageview}) if virtual_pageview
       input_options.delete(:label)
       input_options.delete(:input_class)
-      input_options.delete(:include_object_for_sr)
+      input_options.delete(:sr_text)
 
-      labelled_input attribute, input, input_options, options[:label], screenreader
+      labelled_input attribute, input, input_options, options[:label], sr_text
     end
   end
 
-  def labelled_input attribute, input, input_options, label=nil, screenreader=nil
-
+  def labelled_input(attribute, input, input_options, label = nil, screenreader = nil)
     txt = "#{screenreader}#{label_content_for(attribute, label)}".html_safe
-
-    label = label(attribute, txt )
+    label = label(attribute, txt)
 
     if max_length = max_length(attribute)
       input_options.merge!(maxlength: max_length)

--- a/app/views/claim/_claimant.html.haml
+++ b/app/views/claim/_claimant.html.haml
@@ -3,8 +3,8 @@
   = claimant_header claimant_id
 
   = claim_form.fields_for claimant_field, claimant, builder: LabellingFormBuilder do |form|
-    = form.text_field_row :title,    class: 'title hide js-claimanttype individual', input_class: 'narrow', include_object_for_sr: "Claimant #{claimant_id}"
-    = form.text_field_row :full_name, class: 'hide js-claimanttype individual', include_object_for_sr: "Claimant #{claimant_id}"
+    = form.text_field_row :title,    class: 'title hide js-claimanttype individual', input_class: 'narrow', sr_text: "Claimant #{claimant_id}"
+    = form.text_field_row :full_name, class: 'hide js-claimanttype individual', sr_text: "Claimant #{claimant_id}"
 
     -# we want to execute the following bit of code if non-javascript (:claimant_1) or with javascript ("claimant_{{id}}")
     - if claimant_field == :claimant_1 || claimant_field == 'claimant_{{id}}'

--- a/app/views/claim/_claimant.html.haml
+++ b/app/views/claim/_claimant.html.haml
@@ -3,8 +3,8 @@
   = claimant_header claimant_id
 
   = claim_form.fields_for claimant_field, claimant, builder: LabellingFormBuilder do |form|
-    = form.text_field_row :title,    class: 'title hide js-claimanttype individual', input_class: 'narrow'
-    = form.text_field_row :full_name, class: 'hide js-claimanttype individual'
+    = form.text_field_row :title,    class: 'title hide js-claimanttype individual', input_class: 'narrow', include_object_for_sr: "Claimant #{claimant_id}"
+    = form.text_field_row :full_name, class: 'hide js-claimanttype individual', include_object_for_sr: "Claimant #{claimant_id}"
 
     -# we want to execute the following bit of code if non-javascript (:claimant_1) or with javascript ("claimant_{{id}}")
     - if claimant_field == :claimant_1 || claimant_field == 'claimant_{{id}}'


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/82381722 
Extend the labelling form header to add screen reader help text.
This code will do that, but we need to know where to place the additional data 
e.g. should there be a visually hidden span inside the label, inside the div or somewhere else
`<div class='form-group title hide js-claimanttype individual'>`
`<label for="claim_claimant_1_title">`
`<span class='visuallyhidden'>Claimant 1</span> Title</label>`  **Would this be read as Claimant 1 title?**
`<input class="narrow" id="claim_claimant_1_title" maxlength="8" name="claim[claimant_1][title]" size="8" type="text" />`
`</div>`

