### PR TITLE
Removing deprecation warning for Rails 5.0

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ AcceleratedClaims::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
When running the tests via:

  bundle exec rspec

I'd get this warning:

DEPRECATION WARNING: The configuration option
`config.serve_static_assets` has been renamed to
`config.serve_static_files` to clarify its role (it merely enables
serving everything in the `public` folder and is unrelated to the asset
pipeline). The `serve_static_assets` alias will be removed in Rails
5.0. Please migrate your configuration files accordingly.

Hence this change.