### PR TITLE
Set integration tests to run against app running in docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,13 @@ Unit, lib, routing and controller specs can, and should, be run inside the conta
 	docker exec -i -t <container_id> bash    # get an interactive shell inside the docker container
 	rake spec:docker                         # run all the tests in ```spec/lib spec/models spec/routing spec/controllers```
 
-Feature tests should be run on localhost (the docker container doesn't have phantomjs installed, so the feature tests can't be run from there).
+Feature tests should be run on localhost against the instance running in the container by specifying ```docker``` as the remote environment.  This can also be done using the ```spec:features``` rake task.
 
+	env=docker rspec spec/features
+
+or
+	rake spec:features
+	
 
 ### Dependencies
 * Virtual Box  - install from https://www.virtualbox.org/wiki/Downloads

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -8,7 +8,7 @@ namespace :spec do
 
 	desc 'run feature tests' 
 	task :features do
-		system 'rspec spec/features'
+		system 'env=docker rspec spec/features'
 	end
 	
 end

--- a/spec/remote_test_setup.rb
+++ b/spec/remote_test_setup.rb
@@ -1,11 +1,12 @@
 def remote_hosts
   {
-    'dev' => 'civilclaims.local',
-    'demo'  => 'civilclaims.dsd.io',
-    'demo1' => 'civilclaims.demo1.civilclaims.dsd.io',
-    'demo2' => 'civilclaims.demo2.civilclaims.dsd.io',
-    'staging' => 'civil:mojcivil@civilclaimsstaging.dsd.io',
-    'production' => 'civilclaims.service.gov.uk'
+    'dev' => 'https://civilclaims.local/accelerated-possession-eviction',
+    'demo'  => 'https://civilclaims.dsd.io/accelerated-possession-eviction',
+    'demo1' => 'https://civilclaims.demo1.civilclaims.dsd.io/accelerated-possession-eviction',
+    'demo2' => 'https://civilclaims.demo2.civilclaims.dsd.io/accelerated-possession-eviction',
+    'staging' => 'https://civil:mojcivil@civilclaimsstaging.dsd.io/accelerated-possession-eviction',
+    'production' => 'https://civilclaims.service.gov.uk/accelerated-possession-eviction',
+    'docker' => 'http://localhost:3002'
   }
 end
 
@@ -18,7 +19,8 @@ def remote_host
 end
 
 Capybara.run_server = false
-Capybara.app_host = "https://#{remote_host}/accelerated-possession-eviction"
+Capybara.app_host = remote_host
+
 puts "Running tests remotely against " + Capybara.app_host
 Capybara.default_driver = Capybara.javascript_driver
 WebMock.disable! if defined? WebMock

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,5 +1,5 @@
 def remote_test?
-  ENV['env'].present?
+  ENV['env'].present?  && ENV['env'] != 'docker'
 end
 
 def form_date field, date


### PR DESCRIPTION
- set url for env docker
- force submit_claim_spec to run for env=docker (it doesn't for other remote environments)
- update README
- update spec:features rake task to use docker environment