### PR TITLE
extend_timeout_period

### DIFF
--- a/config/ideal_postcodes.yml
+++ b/config/ideal_postcodes.yml
@@ -1,6 +1,6 @@
 url: https://api.ideal-postcodes.co.uk/v1/postcodes/
 api_key: ak_i09ecaamj9h7zaGvj3Vu1pjpzgdvE
-timeout: 1.5
+timeout: 3.0
 
 
 # response codes


### PR DESCRIPTION
Hi Colin @colinbruce  I have increased the timeout period from 1.5 seconds to 60 seconds. To see if this makes a difference to minor timeouts being alerted in the postcodelookup alert. Do you have access to the postcode downtime to see if this would make a difference - I could increase it by more if need be?