### PR TITLE
add secrets.yml for docker setting up rails.env

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 2aa28b3896def6947d887ad49293e6ef51980f6aae2a48ee95f67ff4d073549e4eb58b5ad83e019c49341196554bf4244ad0e56809615741e680bbf66a01340d
+
+test:
+  secret_key_base: b59d4c118d8dd7d619bd4b531e1c948dd1az97b0bdc2e657ee4d657eb23b72ae71d18608715a56f9593fd2c1u0a14afe61a937a075f2803a1d11e94decf27721
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_TOKEN"] %>


### PR DESCRIPTION
Hi @mattmb  Please can you check and merge. New file "config/secrets.yml". The reason I am including this is because I am getting the following error with my https page:

 raise "Missing `secret_token` and `secret_key_base` for '#{Rails.env}' environment, set these values in `config/secrets.yml`"

This file appears to replace the existing "config/initializers/secret_token.rb" file. I have left it in there as "config/brakeman.ignore" makes reference to it.