### PR TITLE
Added logging when looking up court info

### DIFF
--- a/app/controllers/courtfinder_controller.rb
+++ b/app/controllers/courtfinder_controller.rb
@@ -17,6 +17,7 @@ class CourtfinderController < ApplicationController
   private
 
   def process_court_data(court)
+    LogStuff.error(:court_finder) { "The complete response returned: #{court}" }
     unless court.instance_of? Array
       if court.key? 'error'
         LogStuff.error(:court_finder) { court['error'] }


### PR DESCRIPTION
There is an error where the court info is being retrieved but it isn't
being populated into the page, under 'Court' section.

Adding this logging, in the hope that it'll shed some light as to what
is happening.
