### PR TITLE
Update Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem 'pry-stack_explorer'
   gem 'foreman'
   gem 'fuubar' # Rspec formatter with fast fail.
+  gem 'safe_yaml', '~>1.0.4'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
     rubyzip (1.1.4)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -416,6 +416,7 @@ DEPENDENCIES
   rspec-rails (= 3.4.0)
   rspec_junit_formatter
   ruby-prof
+  safe_yaml (~> 1.0.4)
   sass-rails (~> 4.0.3)
   selenium-webdriver
   show_me_the_cookies


### PR DESCRIPTION
Pegged safe_yaml at 1.0.4, this prevents local Psych::Module errors