### PR TITLE
Update healthcheck

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -14,7 +14,7 @@ class HeartbeatController < ApplicationController
         server: true,
         strike: strike_status
       }
-    }
+    }, status: strike_status ? 200 : 500
   end
 
   def strike_status

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -56,11 +56,15 @@ describe HeartbeatController, :type => :controller do
   end
 
   describe '#healthcheck' do
-    before { get :healthcheck }
-
     it { is_expected.to have_http_status(:success) }
+    before do
+      stub_request(:get, 'http://localhost:4000').to_return(status: status)
+      get :healthcheck
+    end
 
     context 'when everything is ok' do
+      let(:status) { 200 }
+
       let(:expected_response) do
         {
           checks: { server: true, strike: true }
@@ -73,7 +77,8 @@ describe HeartbeatController, :type => :controller do
     end
 
     context 'when strike is down' do
-      before { stub_request(:get, 'http://localhost:4000').to_return(status: 500) }
+
+      let(:status) { 500 }
 
       let(:expected_response) do
         {

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -56,7 +56,6 @@ describe HeartbeatController, :type => :controller do
   end
 
   describe '#healthcheck' do
-    it { is_expected.to have_http_status(:success) }
     before do
       stub_request(:get, 'http://localhost:4000').to_return(status: status)
       get :healthcheck
@@ -70,6 +69,8 @@ describe HeartbeatController, :type => :controller do
           checks: { server: true, strike: true }
         }.to_json
       end
+
+      it { is_expected.to have_http_status(:success) }
 
       it 'returns the expected response report' do
         expect(subject.body).to eq(expected_response)
@@ -85,6 +86,8 @@ describe HeartbeatController, :type => :controller do
           checks: { server: true, strike: false }
         }.to_json
       end
+
+      it { is_expected.to have_http_status(:error) }
 
       it 'returns the expected response report' do
         expect(subject.body).to eq(expected_response)


### PR DESCRIPTION
After testing the implementation on a branch with working tests...

A couple of issues were highlighted:
* we weren't return a 500 status if the tests failed
* the stubbing of the response should have been for all healthcheck tests, not just the failing one.