### PR TITLE
Turn off force_ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ AcceleratedClaims::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true # when turned on server currently redirects request in a way that will never complete
+  # config.force_ssl = true # when turned on server currently redirects request in a way that will never complete
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
We think this causes an issue with load-balancing on AWS

We assume that it was turned on for the non-load-balanced previous host