### PR TITLE
Improve test handling

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -2,13 +2,13 @@ namespace :spec do
 
 	desc 'run all tests in docker container' 
 	task :docker do
-		system 'rspec spec/models spec/lib spec/routing spec/controllers'
+		exit system 'rspec spec/models spec/lib spec/routing spec/controllers'
 	end
 
 
 	desc 'run feature tests' 
 	task :features do
-		system 'env=docker rspec spec/features'
+		exit system 'env=docker rspec spec/features'
 	end
 	
 end

--- a/spec/lib/fail_test_spec.rb
+++ b/spec/lib/fail_test_spec.rb
@@ -1,5 +1,0 @@
-describe 'Failing tests on travis' do
-  it 'will still pass as green' do
-    expect(false).to eql true
-  end
-end

--- a/spec/lib/fail_test_spec.rb
+++ b/spec/lib/fail_test_spec.rb
@@ -1,0 +1,5 @@
+describe 'Failing tests on travis' do
+  it 'will still pass as green' do
+    expect(false).to eql true
+  end
+end


### PR DESCRIPTION
The current tests, when run in travis, return success when they fail!

Adding exit to the RakeTask makes them return the error code.

This was taken from [here](https://github.com/colszowka/simplecov/issues/465) after I tried rolling back simplecov to 0.7 and the monkey-patch described [here](http://www.davekonopka.com/2013/rspec-exit-code.html).