### PR TITLE
Restore feature tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
   - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
   - "phantomjs --version"
 script:
-- bundle exec rake spec:docker
+- xvfb-run -a bundle exec rake spec:docker

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :test do
   gem 'ruby-prof'
   gem 'w3c_validators'
   gem 'capybara-screenshot'
+  gem 'capybara-webkit', '1.11.1'
 end
 
 gem 'pdf-forms', '0.5.5'

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'logstuff'
 
 gem 'nokogiri', '~> 1.6.8'
 gem 'pkg-config'
+gem 'safe_yaml', '~>1.0.4'
+
 group :production, :development do
 #  gem 'newrelic_rpm'
 end
@@ -67,7 +69,6 @@ group :development, :test do
   gem 'pry-stack_explorer'
   gem 'foreman'
   gem 'fuubar' # Rspec formatter with fast fail.
-  gem 'safe_yaml', '~>1.0.4'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     brakeman (3.4.0)
     builder (3.2.2)
     byebug (9.0.5)
-    capybara (2.9.1)
+    capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -54,6 +54,9 @@ GEM
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     ci_reporter (2.0.0)
@@ -371,6 +374,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
+  capybara-webkit (= 1.11.1)
   ci_reporter
   codeclimate-test-reporter
   coffee-rails

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,8 +57,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     echo "# To use docker locally, set:"
     echo "export DOCKER_HOST=tcp://localhost:#{DOCKER_PORT}"
     echo "#---------------------------------------"
-    echo "# To run tests on docker directly, run:"
+    echo "# To run the entire test suite on docker directly:"
     echo "DOCKER_HOST=tcp://localhost:#{DOCKER_PORT} docker exec -ti accelerated-claims rake spec:docker"
+    echo "# To run the tests without the slow running JS submissions:"
+    echo "DOCKER_HOST=tcp://localhost:#{DOCKER_PORT} docker exec -ti accelerated-claims rake spec:all_exclude_js_submit"
+    echo "# To run only the slow running JS submissions:"
+    echo "DOCKER_HOST=tcp://localhost:#{DOCKER_PORT} docker exec -ti accelerated-claims rake spec:features_only_js_submit"
   EOF
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       image: "#{DOCKER_IMAGE_TAG}",
       args: "-v /vagrant:/usr/src/app -p #{UNICORN_PORT}:3000"
   end
+  config.vm.provision "shell", inline: 'docker exec accelerated-claims apt-get install -y qt4-dev-tools libqt4-dev libqt4-core libqt4-gui xvfb'
   config.vm.provision "shell", inline: 'docker exec accelerated-claims bundle install --with development test'
 
   # print out help

--- a/config/initializers/safe_yaml.rb
+++ b/config/initializers/safe_yaml.rb
@@ -1,0 +1,3 @@
+require 'safe_yaml'
+
+SafeYAML::OPTIONS[:default_mode] = :safe

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,14 +1,21 @@
-namespace :spec do 
+namespace :spec do
+  desc 'run all tests in docker container'
+  task :docker do
+    exit system 'rspec'
+  end
 
-	desc 'run all tests in docker container' 
-	task :docker do
-		exit system 'rspec spec/models spec/lib spec/routing spec/controllers'
-	end
+  desc 'Run all tests excluding the submit js tests'
+  task :all_exclude_js_submit do
+    exit system 'rspec --tag ~slow'
+  end
 
-
-	desc 'run feature tests' 
+	desc 'run feature tests'
 	task :features do
 		exit system 'env=docker rspec spec/features'
 	end
-	
+
+  desc 'Run (the normally excluded) submit js tests'
+  task :features_only_js_submit do
+    exit system 'rspec spec/features/submit_claim_spec.rb  --tag slow'
+  end
 end

--- a/spec/features/submit_claim_spec.rb
+++ b/spec/features/submit_claim_spec.rb
@@ -7,9 +7,10 @@ feature "submit claim" do
       receive(:get).and_return(court_address)
   end
 
+  after { Capybara.use_default_driver }
+
   def run_scenario data_file, options={}
     data = load_fixture_data(data_file)
-    expected_summary_data = load_expected_data(data_file)
     expected_data = load_expected_data(data_file)
 
     unless remote_test?
@@ -102,11 +103,15 @@ feature "submit claim" do
     end
 
     unless data['javascript'] == 'NON-JS'
-      eval(%Q|
-        scenario "#{title} with JS: #{description.first} (#{description.last})", js: true do
-          run_scenario '#{data_file}', js: true
-        end
-      |)
+      context 'with JS' do
+        before { Capybara.current_driver = :webkit }
+
+        eval(%Q|
+          scenario "#{title}: #{description.first} (#{description.last})", slow: true, js: true do
+            run_scenario '#{data_file}', js: true
+          end
+        |)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,7 @@ elsif ENV['browser']
   require_relative 'selenium_setup'
   require_relative 'remote_test_setup' if remote_test?
 else
+  require_relative 'webkit_setup'
   require_relative 'poltergeist_setup'
   require_relative 'remote_test_setup' if remote_test?
 end

--- a/spec/support/page_models/confirmation_page.rb
+++ b/spec/support/page_models/confirmation_page.rb
@@ -21,7 +21,7 @@ class ConfirmationPage
     begin
       pdf_filename = capybara_download_pdf
     rescue Capybara::NotSupportedByDriverError, RSpec::Expectations::ExpectationNotMetError
-      pdf_filename = curl_download_pdf
+      pdf_filename = visit_download
     end
 
     pdf_filename
@@ -36,41 +36,21 @@ private
     write_pdf_to_tempfile page.body
   end
 
-  def curl_download_pdf
-    cookie_id = '_accelerated_claims_session'
-    session_id = get_me_the_cookie(cookie_id)[:value]
-
-    http = Curl.get(get_download_url) do |http|
-      http.headers['Cookie'] = "#{cookie_id}=#{session_id}"
-      http.ssl_verify_peer = false
-      http.ssl_verify_host = false
-      http.follow_location = true
-    end
-
-    assert_pdf_content_type(parse_headers http.header_str)
-    write_pdf_to_tempfile http.body_str
+  def visit_download
+    visit('download?flatten=false')
+    sleep 0.1
+    assert_pdf_content_type(page.driver.response_headers)
+    write_pdf_to_tempfile(page.source, true)
   end
 
-  def get_download_url
-    if Capybara.app_host
-      Capybara.app_host + '/download?flatten=false'
-    else
-      Capybara.current_url.gsub(/confirmation$/, 'download?flatten=false')
-    end
-  end
-
-  def write_pdf_to_tempfile(ascii)
+  def write_pdf_to_tempfile(ascii, ignore_8bit_encode=false)
     file = Tempfile.new('pdf_download', encoding: 'utf-8')
-    file.write(ascii.encode("ASCII-8BIT").force_encoding("UTF-8"))
+    ascii.encode("ASCII-8BIT") unless ignore_8bit_encode
+    file.write(ascii.force_encoding("UTF-8"))
     file.path
   end
 
   def assert_pdf_content_type(headers_hash)
     expect(headers_hash['Content-Type']).to eq "application/pdf"
-  end
-
-  def parse_headers(curl_header_string)
-    http_response, *http_headers = curl_header_string.split(/[\r\n]+/).map(&:strip)
-    http_headers = Hash[http_headers.flat_map{ |s| s.scan(/^(\S+): (.+)/) }]
   end
 end

--- a/spec/webkit_setup.rb
+++ b/spec/webkit_setup.rb
@@ -1,0 +1,7 @@
+require 'capybara-webkit'
+
+Capybara::Webkit.configure do |config|
+  config.block_unknown_urls
+end
+
+FileUtils.rm_rf(Dir['/tmp/pdf*pdf'])


### PR DESCRIPTION
The submit claim tests have not worked for some months.

This was, partially, due to the change from deploying and testing on the previous hosts rather than AWS.

This change adds capybara-webkit and tests the download successfully.

The `sleep 0.1` [here](https://github.com/ministryofjustice/accelerated_claims/pull/648/files#diff-440950fce7030a9349548c4e78bd3ed3R41)  is annoying but I cannot find a better method of testing.  I tried `using_wait_time` and increasing the `default_wait_time`, neither of them worked.  The `sleep 0.1` has consistently had a 100% pass rate. :/