### PR TITLE
Adding sentry raven gem for tracking errors.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,10 @@ gem 'statsd-ruby'
 
 gem 'courtfinder-client', '0.0.6'
 
+group :production do
+  gem 'sentry-raven'
+end
+
 group :development, :test do
   gem 'simplecov', require: false
   gem 'rspec-rails', '~>3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,8 @@ GEM
     selenium-webdriver (3.6.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    sentry-raven (2.6.3)
+      faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.10.0)
     shellany (0.0.1)
     show_me_the_cookies (3.1.0)
@@ -419,6 +421,7 @@ DEPENDENCIES
   safe_yaml (~> 1.0.4)
   sass-rails (~> 5.0)
   selenium-webdriver
+  sentry-raven
   show_me_the_cookies
   simplecov
   sprockets (~> 3.7.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,11 +25,13 @@ AcceleratedClaims::Application.routes.draw do
     get  '/accessibility',  controller: :static, action: :accessibility, as: :accessibility
     get  '/terms',          controller: :static, action: :terms, as: :terms
     get  '/expired',        controller: :static, action: :expired, as: :expired
+    get  '/expired/:query_path',  controller: :static, action: :expired, as: :expired_any
 
     get 'ping',             controller: :heartbeat, action: :ping, format: :json
     get 'healthcheck',      controller: :heartbeat, action: :healthcheck, format: :json
-    
+
     post '/expire_session', controller: :application, action: :expire_session
+    post '/expire_session/:query_path', controller: :application, action: :expire_session
     post '/invalid_access_token', controller: :application, action: :invalid_access_token, as: :invalid_access_token
 
     # postcode lookup proxy


### PR DESCRIPTION
I check and the ENV variable is already set in prod so we just need this gem to be added. I also fixed the issue with session expires routes.